### PR TITLE
Sphinx 1.6 needs latexmk to build PDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM       ubuntu:16.04
 ENV DEBIAN_FRONTEND noninteractive
 
 # Update apt-get sources AND install stuff
-RUN apt-get update && apt-get install -y -q texlive texlive-latex-extra texlive-lang-cjk python-pip make
+RUN apt-get update && apt-get install -y -q texlive texlive-latex-extra texlive-lang-cjk python-pip make latexmk
 RUN pip install --upgrade pip
 RUN pip install Sphinx
 RUN pip install recommonmark


### PR DESCRIPTION
From Sphinx's doc/builders.rst:

```
      .. versionchanged:: 1.6
         Use of ``latexmk`` on GNU/Linux or Mac OS X.
```