### PR TITLE
Fix Docker repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# docker-sphinx-recommonmark
+# sphinx-recommonmark
 Sphinx documentation toolchain, latex dependencies and pandoc including [recommonmark](https://github.com/rtfd/recommonmark) in an Ubuntu docker container.
 
 # How to Use it
-docker run -it -v <your directory>:/documents/ chezou/docker-sphinx-recommonmark
+docker run -it -v <your directory>:/documents/ chezou/sphinx-recommonmark
 Use sphinx-quickstart to create a new Sphinx project, and make to use the auto generated Makefile in an existing project. More info in the Sphinx tutorial.
 
 The built container is available at the Docker Hub.


### PR DESCRIPTION
As you've change Docker repository name, I'd recommend updating documents. Also, maybe the name of this github repo had better been changed?