### PR TITLE
Add texlive-lang-japanese and ghostscript dependency explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get -qq update \
         texlive \
         texlive-latex-extra \
         texlive-lang-cjk \
+        texlive-lang-japanese \
+        ghostscript \
         fonts-noto-cjk \
         fonts-noto-cjk-extra \
         make \


### PR DESCRIPTION
Since #5 installs apt packages without recommendation, some popular commands for Japanese like `platex` , `lualatex`, and `gs` were not installed. This change resolves the issue.

This change increases the image size significantly, from 523MB to 1.42GB, so reducing image size would be the future work.